### PR TITLE
Migrate to pandas 2.3.1 and above

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "appdirs==1.*",
     "fastparquet>0.5",
     "numpy==1.*",
-    "pandas==1.*",
+    "pandas>=2.3.1",
 ]
 classifiers = [
     # Trove classifiers. Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This PR migrates the project to support pandas 2.3.1 and above.

## Changes
- Updated pandas dependency from `==1.*` to `>=2.3.1` in pyproject.toml
- Verified code compatibility with pandas 2.x (no deprecated methods found)

Fixes #1

Generated with [Claude Code](https://claude.ai/code)